### PR TITLE
advisory locks on the cleanup process

### DIFF
--- a/tests/test_multiprocess.py
+++ b/tests/test_multiprocess.py
@@ -411,6 +411,13 @@ class TestAdvisoryLock(unittest.TestCase):
             with advisory_lock(LOCK_EX):
                 self.collector.collect(blocking=False)
 
+    def test_exceptions_release_lock(self):
+        with self.assertRaises(ValueError):
+            with advisory_lock(LOCK_EX):
+                raise ValueError
+        # Do an operation which requires acquiring the lock
+        cleanup_dead_processes(blocking=False)
+
     def tearDown(self):
         del os.environ['prometheus_multiproc_dir']
         shutil.rmtree(self.tempdir)

--- a/tests/test_multiprocess.py
+++ b/tests/test_multiprocess.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 
+from fcntl import LOCK_EX, LOCK_SH
 import glob
 import os
 import shutil
@@ -12,7 +13,7 @@ from prometheus_client.core import (
     CollectorRegistry, Counter, Gauge, Histogram, Sample, Summary,
 )
 from prometheus_client.multiprocess import (
-    cleanup_dead_processes, mark_process_dead, MultiProcessCollector
+    advisory_lock, cleanup_dead_processes, mark_process_dead, MultiProcessCollector
 )
 from prometheus_client.values import MultiProcessValue, MutexValue
 
@@ -372,5 +373,45 @@ class TestUnsetEnv(unittest.TestCase):
 
 
 class TestAdvisoryLock(unittest.TestCase):
+    """
+    These tests use lock aqusition as a proxy for cleanup/collect operations,
+    the former using exclusive locks, the latter shared locks
+    """
     def setUp(self):
-        pass
+        self.tempdir = tempfile.mkdtemp()
+        os.environ['prometheus_multiproc_dir'] = self.tempdir
+        values.ValueClass = MultiProcessValue(lambda: 123)
+        self.registry = CollectorRegistry()
+        self.collector = MultiProcessCollector(self.registry, self.tempdir)
+
+    def test_cleanup_waits_for_collectors(self):
+        # IOError in python2, OSError in python3
+        with self.assertRaises(EnvironmentError):
+            with advisory_lock(LOCK_SH):
+                cleanup_dead_processes(blocking=False)
+
+    def test_collect_doesnt_block_other_collects(self):
+        values.ValueClass = MultiProcessValue(lambda: 0)
+        labels = dict((i, i) for i in 'abcd')
+        c = Counter('c', 'help', labelnames=labels.keys(), registry=None)
+        c.labels(**labels).inc(1)
+
+        with advisory_lock(LOCK_SH):
+            metrics = dict((m.name, m) for m in self.collector.collect(blocking=False))
+            self.assertEqual(
+                metrics['c'].samples, [Sample('c_total', labels, 1.0)]
+            )
+
+    def test_collect_waits_for_cleanup(self):
+        values.ValueClass = MultiProcessValue(lambda: 0)
+        labels = dict((i, i) for i in 'abcd')
+        c = Counter('c', 'help', labelnames=labels.keys(), registry=None)
+        c.labels(**labels).inc(1)
+        with self.assertRaises(EnvironmentError):
+            with advisory_lock(LOCK_EX):
+                self.collector.collect(blocking=False)
+
+    def tearDown(self):
+        del os.environ['prometheus_multiproc_dir']
+        shutil.rmtree(self.tempdir)
+        values.ValueClass = MutexValue

--- a/tests/test_multiprocess.py
+++ b/tests/test_multiprocess.py
@@ -369,3 +369,8 @@ class TestUnsetEnv(unittest.TestCase):
 
     def tearDown(self):
         os.remove(self.tmpfl)
+
+
+class TestAdvisoryLock(unittest.TestCase):
+    def setUp(self):
+        pass


### PR DESCRIPTION
<img width="1642" alt="Screen Shot 2020-03-11 at 2 07 30 PM" src="https://user-images.githubusercontent.com/12399070/76463983-abb6f480-63a1-11ea-80e8-3eeeba082dc4.png">

We have a few race conditions when collecting metrics, as files get moved and deleted in the middle of a scrape. Previously, this would result in a 500, and thus a missed scrape. An attempted fix, by ignoring such errors, would end up succeeding, but potentially causing metrics to be missed, resulting in a counter decrement. This happens because we merge metrics from dead processes into a single archive file, and a scrape may be attempted after the file has been moved, but before the merge occurs. Prometheus treats counter decrements are resets, and the counter reset handling kicks in, resulting in spiky metrics

One possible solution is to lock sections of code which read or write to those files. The metrics collector acquires a shared lock, while the cleanup acquires an exclusive lock. This is simple enough that, provided all the lock operations behave as intended, shouldn't have any issues

I can envision two failures, both unlikely to occur, and both non-catastrophic
1. We get high enough traffic to the scrape endpoint that the cleanup thread is forever starved. This will cause metrics files to accumulate, causing scrapes to become more expensive. I assume this will eventually cause the pod to terminate from hitting resource limits. Note that this is basically the behavior of the mainline version of this library.

2. For whatever reason, the lock doesn't get released properly. If it's a shared lock, this prevents the collector from running, with consequences similar to 1. If it's an exclusive lock, the wsgi_simpleapp which serves the scrape endpoint will block indefinitely, causing prometheus scrapes to continuously fail (prometheus has a 10 second timeout on scrape requests by default), and the cleanup will also halt. This will manifest itself as a gap in metrics, but shouldn't affect functionality. The pod could be killed to resolve it.