### PR TITLE
In memory collector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ dist
 .tox
 .*cache
 htmlcov
+.venv
+tmp

--- a/README.md
+++ b/README.md
@@ -512,7 +512,7 @@ Add the following to your Gunicorn config file:
 from prometheus_client import multiprocess_exporter
 
 def on_starting(server):
-    multiprocess.start_cleanup_thread()
+    multiprocess.start_archiver_thread()
 ```
 
 Add the Prometheus Exporter WSGI handler to your existing WSGI handler

--- a/prometheus_client/metrics.py
+++ b/prometheus_client/metrics.py
@@ -312,7 +312,7 @@ class Gauge(MetricWrapperBase):
                  unit='',
                  registry=REGISTRY,
                  labelvalues=None,
-                 multiprocess_mode='all',
+                 multiprocess_mode='latest',
                  ):
         self._multiprocess_mode = multiprocess_mode
         self._f = None

--- a/prometheus_client/multiprocess_exporter.py
+++ b/prometheus_client/multiprocess_exporter.py
@@ -5,7 +5,7 @@ import traceback
 
 from . import (CollectorRegistry, multiprocess)
 from .exposition import make_wsgi_app
-from .multiprocess import cleanup_dead_processes
+from .multiprocess import archive_metrics
 
 
 CLEANUP_INTERVAL = 5.0
@@ -16,20 +16,20 @@ app = make_wsgi_app(registry)
 log = logging.getLogger(__name__)
 
 
-def cleanup_thread():
+def archive_thread():
     while True:
         log.info("startup")
         try:
             log.info("cleaning up")
-            cleanup_dead_processes()
+            archive_metrics()
         except Exception:
             traceback.print_exc()
         time.sleep(CLEANUP_INTERVAL)
 
 
-def start_cleanup_thread():
-    thread.start_new_thread(cleanup_thread, (), {})
+def start_archiver_thread():
+    thread.start_new_thread(archive_thread, (), {})
 
 
 def on_starting(server):
-    start_cleanup_thread()
+    start_archiver_thread()

--- a/prometheus_client/multiprocess_exporter.py
+++ b/prometheus_client/multiprocess_exporter.py
@@ -8,10 +8,12 @@ from .exposition import make_wsgi_app
 from .multiprocess import cleanup_dead_processes
 
 
-CLEANUP_INTERVAL = 60.0
+# TODO: Rename to archive_interval, and all that jazz
+# TODO: Configure PM to lower log level to info
+CLEANUP_INTERVAL = 5.0
 
 registry = CollectorRegistry()
-multiprocess.MultiProcessCollector(registry)
+multiprocess.InMemoryCollector(registry)
 app = make_wsgi_app(registry)
 log = logging.getLogger(__name__)
 

--- a/prometheus_client/multiprocess_exporter.py
+++ b/prometheus_client/multiprocess_exporter.py
@@ -8,8 +8,6 @@ from .exposition import make_wsgi_app
 from .multiprocess import cleanup_dead_processes
 
 
-# TODO: Rename to archive_interval, and all that jazz
-# TODO: Configure PM to lower log level to info
 CLEANUP_INTERVAL = 5.0
 
 registry = CollectorRegistry()

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="prometheus_client",
-    version="0.6.0",
+    version="0.7.1-alpha",
     author="Brian Brazil",
     author_email="brian.brazil@robustperception.io",
     description="Python client for the Prometheus monitoring system.",

--- a/tests/openmetrics/test_exposition.py
+++ b/tests/openmetrics/test_exposition.py
@@ -49,7 +49,7 @@ class TestGenerateText(unittest.TestCase):
                          generate_latest(self.registry))
 
     def test_gauge(self):
-        g = Gauge('gg', 'A gauge', registry=self.registry)
+        g = Gauge('gg', 'A gauge', registry=self.registry, multiprocess_mode='all')
         g.set(17)
         self.assertEqual(b'# HELP gg A gauge\n# TYPE gg gauge\ngg 17.0\n# EOF\n', generate_latest(self.registry))
 

--- a/tests/test_exposition.py
+++ b/tests/test_exposition.py
@@ -71,7 +71,8 @@ cc_created 123.456
 """, generate_latest(self.registry))
 
     def test_gauge(self):
-        g = Gauge('gg', 'A gauge', registry=self.registry)
+        g = Gauge('gg', 'A gauge', registry=self.registry,
+                  multiprocess_mode='all')
         g.set(17)
         self.assertEqual(b'# HELP gg A gauge\n# TYPE gg gauge\ngg 17.0\n', generate_latest(self.registry))
 
@@ -139,13 +140,15 @@ gh_gsum 7.0
             generate_latest(self.registry))
 
     def test_unicode(self):
-        c = Gauge('cc', '\u4500', ['l'], registry=self.registry)
+        c = Gauge('cc', '\u4500', ['l'], registry=self.registry,
+                  multiprocess_mode='all')
         c.labels('\u4500').inc()
         self.assertEqual(b'# HELP cc \xe4\x94\x80\n# TYPE cc gauge\ncc{l="\xe4\x94\x80"} 1.0\n',
                          generate_latest(self.registry))
 
     def test_escaping(self):
-        g = Gauge('cc', 'A\ngaug\\e', ['a'], registry=self.registry)
+        g = Gauge('cc', 'A\ngaug\\e', ['a'], registry=self.registry,
+                  multiprocess_mode='all')
         g.labels('\\x\n"').inc(1)
         self.assertEqual(b'# HELP cc A\\ngaug\\\\e\n# TYPE cc gauge\ncc{a="\\\\x\\n\\""} 1.0\n',
                          generate_latest(self.registry))

--- a/tests/test_multiprocess.py
+++ b/tests/test_multiprocess.py
@@ -13,7 +13,8 @@ from prometheus_client.core import (
     CollectorRegistry, Counter, Gauge, Histogram, Sample, Summary,
 )
 from prometheus_client.multiprocess import (
-    advisory_lock, cleanup_dead_processes, mark_process_dead, MultiProcessCollector
+    advisory_lock, cleanup_dead_processes, mark_process_dead, merge,
+    MultiProcessCollector
 )
 from prometheus_client.values import MultiProcessValue, MutexValue
 
@@ -269,7 +270,7 @@ class TestMultiProcess(unittest.TestCase):
         path = os.path.join(os.environ['prometheus_multiproc_dir'], '*.db')
         files = glob.glob(path)
         metrics = dict(
-            (m.name, m) for m in self.collector.merge(files, accumulate=False)
+            (m.name, m) for m in merge(files, accumulate=False)
         )
 
         metrics['h'].samples.sort(
@@ -302,7 +303,7 @@ class TestMultiProcess(unittest.TestCase):
         # called during self.collector.collect(), after the glob found it
         # but before the merge actually happened.
         # This should not raise and return no metrics
-        self.assertFalse(self.collector.merge([
+        self.assertFalse(merge([
             os.path.join(self.tempdir, 'gauge_liveall_9999999.db'),
             os.path.join(self.tempdir, 'gauge_livesum_9999999.db'),
         ]))

--- a/tests/test_multiprocess.py
+++ b/tests/test_multiprocess.py
@@ -79,9 +79,9 @@ class TestMultiProcess(unittest.TestCase):
 
     def test_gauge_all(self):
         values.ValueClass = MultiProcessValue(lambda: 123)
-        g1 = Gauge('g', 'help', registry=None)
+        g1 = Gauge('g', 'help', registry=None, multiprocess_mode='all')
         values.ValueClass = MultiProcessValue(lambda: 456)
-        g2 = Gauge('g', 'help', registry=None)
+        g2 = Gauge('g', 'help', registry=None, multiprocess_mode='all')
         self.assertEqual(0, self.registry.get_sample_value('g', {'pid': '123'}))
         self.assertEqual(0, self.registry.get_sample_value('g', {'pid': '456'}))
         g1.set(1)
@@ -204,7 +204,8 @@ class TestMultiProcess(unittest.TestCase):
             return l
 
         c = Counter('c', 'help', labelnames=labels.keys(), registry=None)
-        g = Gauge('g', 'help', labelnames=labels.keys(), registry=None)
+        g = Gauge('g', 'help', labelnames=labels.keys(), registry=None,
+                  multiprocess_mode='all')
         h = Histogram('h', 'help', labelnames=labels.keys(), registry=None)
 
         c.labels(**labels).inc(1)


### PR DESCRIPTION
This PR adds another collection strategy in the form of the `InMemoryCollector`
 * The Cleanup task now runs with a 5 second pause in between, down from a minute
 * The Cleanup task now processes metrics from live processes, appends them to the existing archived metrics files, and stores it in a `MetricsCache`.
 * The InMemoryCollector simply reads out the current value of `MetricsCache`. Additionally, MetricsCache is a collector itself, emitting metrics on how long the last cleanup task took to run

Additionally, I've made the default gauge multiprocess_strategy `latest`, instead of `all`. All gauges are generally not what people want in postal-main, and lead to unbounded disk usage.